### PR TITLE
Display "Empty" for empty notes in the note list #17

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,7 @@ const text = computed({
   set(newValue) {
     const id = selected.value[0];
     const index = notes.value.findIndex((x) => x.id === id);
-    const newNote = { id, text: newValue };
+    const newNote = { id, text: newValue, noteName: newValue.trim() ? newValue : "Empty" };
     notes.value = [
       newNote,
       ...notes.value.slice(0, index),
@@ -45,7 +45,7 @@ watch([isListShow, selected], async () => {
 
 const addNote = () => {
   const id = Math.random().toString(36).slice(2);
-  const newNote = { id, text: "" };
+  const newNote = { id, text: "", noteName: "Empty"};
   notes.value = [newNote, ...notes.value].slice(0, MAX_NOTE_COUNT);
   selected.value = [id];
 };
@@ -87,7 +87,7 @@ addNote();
             :items="notes"
             class="d-flex flex-column list"
             density="compact"
-            item-title="text"
+            item-title="noteName"
             item-value="id"
             :mandatory="true"
           />

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,11 +64,11 @@ addNote();
         <!-- ナビゲーション メニュー -->
         <div class="d-flex h-100">
           <v-list class="d-flex flex-column h-100">
-            <v-list-item @click="addNote">
-              <v-list-item-icon icon="mdi-creation" />
-            </v-list-item>
             <v-list-item @click="toggleList">
               <v-list-item-icon icon="mdi-note-multiple-outline" />
+            </v-list-item>
+            <v-list-item @click="addNote">
+              <v-list-item-icon icon="mdi-creation" />
             </v-list-item>
             <v-list-item
               class="mt-auto"

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,9 +19,6 @@ const text = computed({
   get() {
     const id = selected.value[0];
     const note = notes.value.find((x) => x.id === id);
-    if(note.text == ""){
-      note.text = "Empty"
-    }
     return note.text;
   },
   set(newValue) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,10 @@ const text = computed({
   get() {
     const id = selected.value[0];
     const note = notes.value.find((x) => x.id === id);
+    if(note.text == ""){
+      note.text = "Empty"
+    }
+    console.log(counter);
     return note.text;
   },
   set(newValue) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,7 +22,6 @@ const text = computed({
     if(note.text == ""){
       note.text = "Empty"
     }
-    console.log(counter);
     return note.text;
   },
   set(newValue) {


### PR DESCRIPTION
The following code prints empty on the textarea when it is empty
Things I attempted before taking this path towards the solution:
- I tried changing value in list **only** however that wasn't possible as whenever I changes value in list the change would show up in text area
- I tried setting changing it into file but whenever I did that the change would again still appear in the text area as well
> Warning: This method of solving this problem can cause multiple recursions: 

1: When the file opens it directly shows "Empty" as default text
![image](https://user-images.githubusercontent.com/93852415/180560362-6855a46e-58ad-4113-b7d0-dcd51aee88cb.png)

2: if the user goes on to clear the text one-by-one then the user will again get empty printed on his textarea
![N - Google Chrome 2022-07-23 02-03-41](https://user-images.githubusercontent.com/93852415/180561395-0abff905-f773-498b-973a-b8cba61fd5be.gif)

3: The only way to modify the content is to select the text and then directly start typing
![N - Google Chrome 2022-07-23 02-03-55](https://user-images.githubusercontent.com/93852415/180562318-e941d79b-ec16-4c33-9078-3306b7b2c4bc.gif)


Do review the file and tell if any more changes are needed, THANK YOU!!