### PR TITLE
Do not add new note if top of note list is empty note #20

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,7 +66,7 @@ function App() {
 
   const addNote = () => {
     if(notes.length >0){
-      if (notes[0].noteName === "Empty"){
+      if (notes[0].text.trim() === ""){
         textarea.current.focus();
         return;
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,12 @@ function App() {
   // メソッド ハンドラー
 
   const addNote = () => {
+    if(notes.length >0){
+      if (notes[0].noteName === "Empty"){
+        textarea.current.focus();
+        return;
+      }
+    }
     const id = Math.random().toString(36).slice(2);
     const newNote = { id, text: "", noteName: "Empty" };
     setNotes([newNote, ...notes].slice(0, MAX_NOTE_COUNT));


### PR DESCRIPTION
Problem Description:
-
When the previous note is already empty a new note shouldn't be added

Problems Faced:
-
How to find out if previous file is empty.

Approach 1:
-
Use the noteName Attribute for the previous name at index 0

**Problems with approach**:
- If user enters Empty in the file then the noteName attribute will still be empty leaving with a situation where note is filled but still new note cant be made
- Can also create a problem of storage

Approach 2 (Selected Approach):
-
Instead of checking the noteName attribute we can easily check the Text attribute
In this case there wont be a possibility of a fine with the words "empty" present and new file not opening
>The trim attribute is also used incase the user just uses a space or the 'ENTER' button only 

